### PR TITLE
Added a headermap to the storage client to allow for authenticated requests

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -26,6 +26,7 @@ impl StorageClient {
             client: reqwest::Client::new(),
             project_url,
             api_key,
+            headers: HeaderMap::new(),
         }
     }
 
@@ -46,6 +47,7 @@ impl StorageClient {
             client: reqwest::Client::new(),
             project_url,
             api_key,
+            headers: HeaderMap::new(),
         })
     }
 
@@ -72,12 +74,14 @@ impl StorageClient {
         allowed_mime_types: Option<Vec<MimeType<'a>>>,
         file_size_limit: Option<u64>,
     ) -> Result<String, Error> {
-        let mut headers = HeaderMap::new();
+        let mut headers = self.headers.clone();
         headers.insert(HEADER_API_KEY, HeaderValue::from_str(&self.api_key)?);
-        headers.insert(
-            AUTHORIZATION,
-            HeaderValue::from_str(&format!("Bearer {}", &self.api_key))?,
-        );
+        if !headers.contains_key(AUTHORIZATION) {
+            headers.insert(
+                AUTHORIZATION,
+                HeaderValue::from_str(&format!("Bearer {}", &self.api_key))?,
+            );
+        }
         headers.insert(CONTENT_TYPE, HeaderValue::from_str("application/json")?);
 
         // Convert MimeType enums to their string representations
@@ -121,11 +125,13 @@ impl StorageClient {
     /// client.delete_bucket("a-cool-name-for-a-bucket").await.unwrap();
     /// ```
     pub async fn delete_bucket(&self, id: &str) -> Result<(), Error> {
-        let mut headers = HeaderMap::new();
-        headers.insert(
-            AUTHORIZATION,
-            HeaderValue::from_str(&format!("Bearer {}", &self.api_key))?,
-        );
+        let mut headers = self.headers.clone();
+        if !headers.contains_key(AUTHORIZATION) {
+            headers.insert(
+                AUTHORIZATION,
+                HeaderValue::from_str(&format!("Bearer {}", &self.api_key))?,
+            );
+        }
 
         let res = self
             .client
@@ -156,11 +162,13 @@ impl StorageClient {
     ///     .unwrap();
     ///```
     pub async fn get_bucket(&self, bucket_id: &str) -> Result<Bucket, Error> {
-        let mut headers = HeaderMap::new();
-        headers.insert(
-            AUTHORIZATION,
-            HeaderValue::from_str(&format!("Bearer {}", &self.api_key))?,
-        );
+        let mut headers = self.headers.clone();
+        if !headers.contains_key(AUTHORIZATION) {
+            headers.insert(
+                AUTHORIZATION,
+                HeaderValue::from_str(&format!("Bearer {}", &self.api_key))?,
+            );
+        }
         headers.insert(CONTENT_TYPE, HeaderValue::from_str("application/json")?);
 
         let res = self
@@ -190,11 +198,13 @@ impl StorageClient {
     /// let buckets = client.list_buckets().await.unwrap();
     /// ```
     pub async fn list_buckets(&self) -> Result<Buckets, Error> {
-        let mut headers = HeaderMap::new();
-        headers.insert(
-            AUTHORIZATION,
-            HeaderValue::from_str(&format!("Bearer {}", &self.api_key))?,
-        );
+        let mut headers = self.headers.clone();
+        if !headers.contains_key(AUTHORIZATION) {
+            headers.insert(
+                AUTHORIZATION,
+                HeaderValue::from_str(&format!("Bearer {}", &self.api_key))?,
+            );
+        }
         headers.insert(CONTENT_TYPE, HeaderValue::from_str("application/json")?);
 
         let res = self
@@ -231,12 +241,14 @@ impl StorageClient {
         allowed_mime_types: Option<Vec<MimeType<'a>>>,
         file_size_limit: Option<u64>,
     ) -> Result<String, Error> {
-        let mut headers = HeaderMap::new();
+        let mut headers = self.headers.clone();
         headers.insert(HEADER_API_KEY, HeaderValue::from_str(&self.api_key)?);
-        headers.insert(
-            AUTHORIZATION,
-            HeaderValue::from_str(&format!("Bearer {}", &self.api_key))?,
-        );
+        if !headers.contains_key(AUTHORIZATION) {
+            headers.insert(
+                AUTHORIZATION,
+                HeaderValue::from_str(&format!("Bearer {}", &self.api_key))?,
+            );
+        }
         headers.insert(CONTENT_TYPE, HeaderValue::from_str("application/json")?);
 
         // Convert MimeType enums to their string representations
@@ -278,12 +290,14 @@ impl StorageClient {
     /// let empty = client.empty_bucket("empty_bucket_test").await.unwrap();
     /// ```
     pub async fn empty_bucket(&self, id: &str) -> Result<String, Error> {
-        let mut headers = HeaderMap::new();
+        let mut headers = self.headers.clone();
         headers.insert(HEADER_API_KEY, HeaderValue::from_str(&self.api_key)?); // maybe delete
-        headers.insert(
-            AUTHORIZATION,
-            HeaderValue::from_str(&format!("Bearer {}", &self.api_key))?,
-        );
+        if !headers.contains_key(AUTHORIZATION) {
+            headers.insert(
+                AUTHORIZATION,
+                HeaderValue::from_str(&format!("Bearer {}", &self.api_key))?,
+            );
+        }
 
         let res = self
             .client
@@ -315,11 +329,13 @@ impl StorageClient {
         update: bool,
         options: Option<FileOptions<'_>>,
     ) -> Result<ObjectResponse, Error> {
-        let mut headers = HeaderMap::new();
-        headers.insert(
-            AUTHORIZATION,
-            HeaderValue::from_str(&format!("Bearer {}", &self.api_key))?,
-        );
+        let mut headers = self.headers.clone();
+        if !headers.contains_key(AUTHORIZATION) {
+            headers.insert(
+                AUTHORIZATION,
+                HeaderValue::from_str(&format!("Bearer {}", &self.api_key))?,
+            );
+        }
 
         // Set optional headers
         if let Some(opts) = options {
@@ -447,11 +463,13 @@ impl StorageClient {
         path: &str,
         options: Option<DownloadOptions<'_>>,
     ) -> Result<Vec<u8>, Error> {
-        let mut headers = HeaderMap::new();
-        headers.insert(
-            AUTHORIZATION,
-            HeaderValue::from_str(&format!("Bearer {}", &self.api_key))?,
-        );
+        let mut headers = self.headers.clone();
+        if !headers.contains_key(AUTHORIZATION) {
+            headers.insert(
+                AUTHORIZATION,
+                HeaderValue::from_str(&format!("Bearer {}", &self.api_key))?,
+            );
+        }
 
         let mut renderpath = "object";
         if let Some(opts) = options {
@@ -492,11 +510,13 @@ impl StorageClient {
     ///     .unwrap();
     ///```
     pub async fn delete_file(&self, bucket_id: &str, path: &str) -> Result<BucketResponse, Error> {
-        let mut headers = HeaderMap::new();
-        headers.insert(
-            AUTHORIZATION,
-            HeaderValue::from_str(&format!("Bearer {}", &self.api_key))?,
-        );
+        let mut headers = self.headers.clone();
+        if !headers.contains_key(AUTHORIZATION) {
+            headers.insert(
+                AUTHORIZATION,
+                HeaderValue::from_str(&format!("Bearer {}", &self.api_key))?,
+            );
+        }
 
         let res = self
             .client
@@ -549,12 +569,14 @@ impl StorageClient {
         path: Option<&str>,
         options: Option<FileSearchOptions<'_>>,
     ) -> Result<Vec<FileObject>, Error> {
-        let mut headers = HeaderMap::new();
+        let mut headers = self.headers.clone();
         headers.insert(CONTENT_TYPE, HeaderValue::from_str("application/json")?);
-        headers.insert(
-            AUTHORIZATION,
-            HeaderValue::from_str(&format!("Bearer {}", &self.api_key))?,
-        );
+        if !headers.contains_key(AUTHORIZATION) {
+            headers.insert(
+                AUTHORIZATION,
+                HeaderValue::from_str(&format!("Bearer {}", &self.api_key))?,
+            );
+        }
 
         let options = options.unwrap_or_default();
         let payload = ListFilesPayload {
@@ -614,12 +636,14 @@ impl StorageClient {
         to_path: Option<&str>,
         copy_metadata: bool,
     ) -> Result<String, Error> {
-        let mut headers = HeaderMap::new();
+        let mut headers = self.headers.clone();
         headers.insert(CONTENT_TYPE, HeaderValue::from_str("application/json")?);
-        headers.insert(
-            AUTHORIZATION,
-            HeaderValue::from_str(&format!("Bearer {}", &self.api_key))?,
-        );
+        if !headers.contains_key(AUTHORIZATION) {
+            headers.insert(
+                AUTHORIZATION,
+                HeaderValue::from_str(&format!("Bearer {}", &self.api_key))?,
+            );
+        }
 
         let payload = CopyFilePayload {
             bucket_id: from_bucket,
@@ -667,12 +691,14 @@ impl StorageClient {
         path: &str,
         expires_in: u64,
     ) -> Result<String, Error> {
-        let mut headers = HeaderMap::new();
+        let mut headers = self.headers.clone();
         headers.insert(CONTENT_TYPE, HeaderValue::from_str("application/json")?);
-        headers.insert(
-            AUTHORIZATION,
-            HeaderValue::from_str(&format!("Bearer {}", &self.api_key))?,
-        );
+        if !headers.contains_key(AUTHORIZATION) {
+            headers.insert(
+                AUTHORIZATION,
+                HeaderValue::from_str(&format!("Bearer {}", &self.api_key))?,
+            );
+        }
 
         let payload = CreateSignedUrlPayload { expires_in };
 
@@ -717,12 +743,14 @@ impl StorageClient {
         paths: Vec<&str>,
         expires_in: u64,
     ) -> Result<Vec<String>, Error> {
-        let mut headers = HeaderMap::new();
+        let mut headers = self.headers.clone();
         headers.insert(CONTENT_TYPE, HeaderValue::from_str("application/json")?);
-        headers.insert(
-            AUTHORIZATION,
-            HeaderValue::from_str(&format!("Bearer {}", &self.api_key))?,
-        );
+        if !headers.contains_key(AUTHORIZATION) {
+            headers.insert(
+                AUTHORIZATION,
+                HeaderValue::from_str(&format!("Bearer {}", &self.api_key))?,
+            );
+        }
 
         let payload = CreateMultipleSignedUrlsPayload { expires_in, paths };
 
@@ -769,11 +797,13 @@ impl StorageClient {
         bucket_id: &str,
         path: &str,
     ) -> Result<SignedUploadUrlResponse, Error> {
-        let mut headers = HeaderMap::new();
-        headers.insert(
-            AUTHORIZATION,
-            HeaderValue::from_str(&format!("Bearer {}", &self.api_key))?,
-        );
+        let mut headers = self.headers.clone();
+        if !headers.contains_key(AUTHORIZATION) {
+            headers.insert(
+                AUTHORIZATION,
+                HeaderValue::from_str(&format!("Bearer {}", &self.api_key))?,
+            );
+        }
 
         let res = self
             .client
@@ -814,11 +844,13 @@ impl StorageClient {
         path: &str,
         options: Option<FileOptions<'_>>,
     ) -> Result<UploadToSignedUrlResponse, Error> {
-        let mut headers = HeaderMap::new();
-        headers.insert(
-            AUTHORIZATION,
-            HeaderValue::from_str(&format!("Bearer {}", &self.api_key))?,
-        );
+        let mut headers = self.headers.clone();
+        if !headers.contains_key(AUTHORIZATION) {
+            headers.insert(
+                AUTHORIZATION,
+                HeaderValue::from_str(&format!("Bearer {}", &self.api_key))?,
+            );
+        }
 
         // Set optional headers
         if let Some(opts) = options {
@@ -940,12 +972,14 @@ impl StorageClient {
         from_path: &str,
         to_path: &str,
     ) -> Result<String, Error> {
-        let mut headers = HeaderMap::new();
+        let mut headers = self.headers.clone();
         headers.insert(CONTENT_TYPE, HeaderValue::from_str("application/json")?);
-        headers.insert(
-            AUTHORIZATION,
-            HeaderValue::from_str(&format!("Bearer {}", &self.api_key))?,
-        );
+        if !headers.contains_key(AUTHORIZATION) {
+            headers.insert(
+                AUTHORIZATION,
+                HeaderValue::from_str(&format!("Bearer {}", &self.api_key))?,
+            );
+        }
 
         let payload = MoveFilePayload {
             bucket_id: from_bucket,

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,5 +1,5 @@
 use reqwest::{
-    header::{HeaderMap, HeaderValue, AUTHORIZATION, CACHE_CONTROL, CONTENT_TYPE},
+    header::{HeaderMap, HeaderValue, IntoHeaderName, AUTHORIZATION, CACHE_CONTROL, CONTENT_TYPE},
     Url,
 };
 
@@ -49,6 +49,18 @@ impl StorageClient {
             api_key,
             headers: HeaderMap::new(),
         })
+    }
+
+    pub fn insert_header(
+        mut self,
+        header_name: impl IntoHeaderName,
+        header_value: impl AsRef<str>,
+    ) -> Self {
+        self.headers.insert(
+            header_name,
+            HeaderValue::from_str(header_value.as_ref()).expect("Invalid header value."),
+        );
+        self
     }
 
     /// Create a new storage bucket, returning the name **_(not the id)_** of the bucket on success.

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,6 +1,6 @@
 use std::{fmt, time::Duration};
 
-use reqwest::Client;
+use reqwest::{header::HeaderMap, Client};
 use serde::{Deserialize, Serialize};
 
 /// Supabase Storage Client
@@ -12,6 +12,7 @@ pub struct StorageClient {
     pub project_url: String,
     /// WARN: The `service role` key has the ability to bypass Row Level Security. Never share it publicly.
     pub api_key: String,
+    pub(crate) headers: HeaderMap,
 }
 
 #[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq)]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Added a headermap to the storage client to allow for authenticated requests

## What is the current behavior?

It's only possible to make anonymous requests

## What is the new behavior?

It's possible to make authenticated requests

## Additional context

I roughly followed the way it's done here https://github.com/supabase-community/postgrest-rs